### PR TITLE
[dconf] read locked keys and skip them during gconf to dconf migration.

### DIFF
--- a/rpm/gconf2dconf.cpp
+++ b/rpm/gconf2dconf.cpp
@@ -266,13 +266,15 @@ get_locked_keys () {
 
     struct dirent *ent;
     while ((ent = readdir(d)) != 0) {
+      std::string path;
       try {
 	if (ent->d_name[0] != '.') {
-	  std::string path = dirs[x];
+	  path = dirs[x];
 	  path += ent->d_name;
 	  get_locked_keys (path, locked_keys);
 	}
       } catch (...) {
+	std::cerr << "Failed to read locked keys from " << path << std::endl;
 	continue;
       }
     }


### PR DESCRIPTION
If we don't skip them then the we fail to save the DConf changeset

I also indented the file so the change looks larger than it is really.
