### PR TITLE
[dconf] introduce vendor-variant profile. Contributes to JB#32433

### DIFF
--- a/README
+++ b/README
@@ -1,16 +1,18 @@
 dconf databases:
 ================
-We have 3 databases.
+We have 4 databases.
   - A read only system database called "nemo" which is used to store configuration for packages coming from nemo.
   - A read only system database called "vendor". This allows vendors to override and customize stuff.
     An example is the theme. Nemo has its theme and the nemo database contains the name of it.
     A vendor (like Jolla can override it with its own theme and store that info in the vendor db).
+  - A read only system database called "vendor-variant" which can be used if a vendor needs to produce multiple variants.
   - A read/write db called user which contains the configuration.
 
 Configuration file which specifies the databases is stored in /etc/dconf/profile/user
-  - User db is in: /home/nemo/.config/dconf/user
+  - user db is in: /home/nemo/.config/dconf/user
   - nemo db is in: /etc/dconf/db/nemo
   - vendor db is stored in /etc/dconf/db/vendor
+  - vendor-variant db is stored in /etc/dconf/db/vendor-variant
 
 Adding app specific defaults:
 =============================

--- a/rpm/dconf.spec
+++ b/rpm/dconf.spec
@@ -61,6 +61,7 @@ mkdir -p %{buildroot}/%{_sysconfdir}/dconf/profile/
 cp %SOURCE1 %{buildroot}/%{_sysconfdir}/dconf/profile/
 mkdir -p %{buildroot}/%{_sysconfdir}/dconf/db/nemo.d/
 mkdir -p %{buildroot}/%{_sysconfdir}/dconf/db/vendor.d/
+mkdir -p %{buildroot}/%{_sysconfdir}/dconf/db/vendor-variant.d/
 mkdir -p %{buildroot}/%{_oneshotdir}
 cp -a %SOURCE2 %{buildroot}/%{_oneshotdir}
 cp -a %SOURCE3 %{buildroot}/%{_oneshotdir}
@@ -69,6 +70,7 @@ cp -a gconf2dconf %{buildroot}/%{_bindir}
 # Needed for ghosting
 touch %{buildroot}/%{_sysconfdir}/dconf/db/nemo
 touch %{buildroot}/%{_sysconfdir}/dconf/db/vendor
+touch %{buildroot}/%{_sysconfdir}/dconf/db/vendor-variant
 
 %post
 /sbin/ldconfig
@@ -94,6 +96,8 @@ touch %{buildroot}/%{_sysconfdir}/dconf/db/vendor
 %ghost %{_sysconfdir}/dconf/db/nemo
 %{_sysconfdir}/dconf/db/vendor.d/
 %ghost %{_sysconfdir}/dconf/db/vendor
+%{_sysconfdir}/dconf/db/vendor-variant.d/
+%ghost %{_sysconfdir}/dconf/db/vendor-variant
 %attr(755, root, root) %{_oneshotdir}/dconf-update
 %attr(755, root, root) %{_oneshotdir}/dconf-migrate
 

--- a/rpm/user
+++ b/rpm/user
@@ -1,3 +1,4 @@
 user-db:user
+system-db:vendor-variant
 system-db:vendor
 system-db:nemo


### PR DESCRIPTION
This profile should be used in case a vendor needs to produce multiple
variants overriding some base configuration
